### PR TITLE
feat: implement plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ This option is used for configuring options such as `rtl`, `namespace`, `ie`, et
 
 ### `path`
 
-- Default: `'atomic.css'`
+- Default: `'./atomic.css'`
 
 This option is used to configure where the plugin will write the CSS Atomizer generates.
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-module.exports = () => {
-	return tree => tree;
-};
+const Plugin = require('./plugin');
+
+module.exports = Plugin.instance;

--- a/index.test.js
+++ b/index.test.js
@@ -1,7 +1,0 @@
-const PostHtmlAtomizer = require('.');
-
-describe('PostHtmlAtomizer', () => {
-	test('canary', () => {
-		expect(PostHtmlAtomizer()({tag: 'html'})).toEqual({tag: 'html'});
-	});
-});

--- a/node.js
+++ b/node.js
@@ -1,0 +1,24 @@
+const Get = require('lodash.get');
+
+const Node = exports;
+
+function classAttribute(node) {
+	return Get(node, 'attrs.class', '');
+}
+
+function map(tree, fn) {
+	const result = [];
+
+	tree.walk(node => {
+		if (node.tag) {
+			result.push(fn(node));
+		}
+
+		return node;
+	});
+
+	return result;
+}
+
+Node.classAttribute = classAttribute;
+Node.map = map;

--- a/node.test.js
+++ b/node.test.js
@@ -1,0 +1,54 @@
+const PostHtml = require('posthtml');
+
+const Node = require('./node');
+
+function tree(html) {
+	return new PostHtml(tree => tree).process(html, {sync: true}).tree;
+}
+
+describe('Node', () => {
+	describe('.classAttribute', () => {
+		test('class', () => {
+			expect(Node.classAttribute({attrs: {class: 'wow ok'}})).toEqual('wow ok');
+		});
+
+		test('no class', () => {
+			expect(Node.classAttribute({attrs: {notClass: ''}})).toEqual('');
+		});
+
+		test('no attrs', () => {
+			expect(Node.classAttribute({notAttrs: {notClass: ''}})).toEqual('');
+		});
+	});
+
+	describe('.map', () => {
+		test('no untagged nodes', () => {
+			expect(
+				Node.map(
+					tree('<html><head></head><body><div></div></body></html>'),
+					node => node.tag,
+				),
+			).toEqual(['html', 'head', 'body', 'div']);
+		});
+
+		test('untagged nodes', () => {
+			expect(
+				Node.map(
+					tree(`
+				<!DOCTYPE HTML>
+				<html>
+					<head>
+						<title>foo</title>
+						<style>h1 { background-color: red; }</style>
+					</head>
+					<body>
+						<main>bar</main>
+					</body>
+				</html>
+			`),
+					node => node.tag,
+				),
+			).toEqual(['html', 'head', 'title', 'style', 'body', 'main']);
+		});
+	});
+});

--- a/option.js
+++ b/option.js
@@ -1,0 +1,34 @@
+const Joi = require('joi');
+const Merge = require('lodash.merge');
+
+const Option = exports;
+
+const SCHEMA = Joi.object().keys({
+	atomizer: Joi.object().keys({
+		config: Joi.object(),
+		options: Joi.object(),
+	}),
+	path: Joi.string()
+		.uri({allowRelative: true})
+		.trim(),
+});
+
+function defaults(options) {
+	return Merge(
+		{
+			path: './atomic.css',
+			atomizer: {
+				config: {},
+				options: {},
+			},
+		},
+		options,
+	);
+}
+
+function validate(options) {
+	return Joi.attempt(options, SCHEMA);
+}
+
+Option.defaults = defaults;
+Option.validate = validate;

--- a/option.test.js
+++ b/option.test.js
@@ -1,0 +1,39 @@
+const Option = require('./option');
+
+describe('Option', () => {
+	describe('.defaults', () => {
+		test('keys', () => {
+			const instance = Option.defaults();
+
+			expect(Object.keys(instance).sort()).toEqual(['atomizer', 'path']);
+			expect(Object.keys(instance.atomizer).sort()).toEqual([
+				'config',
+				'options',
+			]);
+		});
+	});
+
+	describe('.validate', () => {
+		test('returns valid', () => {
+			const options = {
+				atomizer: {
+					config: {
+						classNames: ['Bd(1)'],
+					},
+					options: {
+						ie: true,
+					},
+				},
+				path: './foo.css',
+			};
+
+			expect(Option.validate(options)).toEqual(options);
+		});
+
+		test('throws invalid', () => {
+			expect(() => {
+				Option.validate({path: 1});
+			}).toThrow();
+		});
+	});
+});

--- a/package.json
+++ b/package.json
@@ -21,7 +21,13 @@
 		"test:debug:cmd": "echo $(which jest) --collectCoverage false --runInBand",
 		"test:debug:inspect": "node --inspect-brk $(yarn --silent run test:debug:cmd)"
 	},
-	"dependencies": {},
+	"dependencies": {
+		"atomizer": "^3.4.7",
+		"joi": "^13.1.2",
+		"lodash.get": "^4.4.2",
+		"lodash.merge": "^4.6.1",
+		"mkdirp": "^0.5.1"
+	},
 	"devDependencies": {
 		"@commitlint/cli": "^6.1.3",
 		"@commitlint/config-conventional": "^6.1.3",
@@ -33,9 +39,11 @@
 		"node": "^6.13.0",
 		"npm-run-all": "^4.1.2",
 		"npx": "^10.0.1",
+		"posthtml": "^0.11.3",
 		"prettier": "^1.11.1",
 		"prettier-package-json": "^1.5.1",
 		"standard-version": "^4.3.0",
+		"tempy": "^0.2.1",
 		"xo": "^0.20.3",
 		"yarn": "^1.5.1",
 		"yarn-bin-fix": "^0.1.15"

--- a/plugin.js
+++ b/plugin.js
@@ -1,0 +1,28 @@
+const Fs = require('fs');
+const Mkdirp = require('mkdirp');
+const Path = require('path');
+
+const Node = require('./node');
+const Option = require('./option');
+const Style = require('./style');
+
+const Plugin = exports;
+
+function instance(options) {
+	options = Option.validate(options);
+	options = Option.defaults(options);
+
+	const style = Style.instance(options.atomizer);
+
+	return tree => {
+		const classes = Node.map(tree, node => Node.classAttribute(node));
+		const css = style.generate(classes.join(' '));
+
+		Mkdirp.sync(Path.dirname(options.path));
+		Fs.writeFileSync(options.path, css);
+
+		return tree;
+	};
+}
+
+Plugin.instance = instance;

--- a/plugin.test.js
+++ b/plugin.test.js
@@ -1,0 +1,52 @@
+const Fs = require('fs');
+const PostHtml = require('posthtml');
+const Tempy = require('tempy');
+
+const Plugin = require('./plugin');
+
+describe('Plugin', () => {
+	describe('.instance', () => {
+		let path;
+
+		beforeEach(() => {
+			path = Tempy.file();
+		});
+
+		afterEach(() => {
+			if (Fs.existsSync(path)) {
+				Fs.unlinkSync(path);
+			}
+		});
+
+		test('posthtml plugin', () => {
+			return new PostHtml([Plugin.instance({path})])
+				.process(
+					`
+			<html>
+			<body>
+				<main class="P(20px)">
+					<article class="C(red)">foo</article>
+					<article class="C(white)">bar</article>
+					<article class="C(blue)">baz</article>
+				</main>
+			</body>
+			</html>
+			`,
+				)
+				.then(() => {
+					expect(
+						Fs.readFileSync(path)
+							.toString()
+							.split('\n'),
+					).toEqual(
+						expect.arrayContaining([
+							expect.stringContaining('P\\(20px\\)'),
+							expect.stringContaining('C\\(red\\)'),
+							expect.stringContaining('C\\(white\\)'),
+							expect.stringContaining('C\\(blue\\)'),
+						]),
+					);
+				});
+		});
+	});
+});

--- a/style.js
+++ b/style.js
@@ -1,0 +1,23 @@
+const Atomizer = require('atomizer');
+
+class Style {
+	static instance({config, options}) {
+		return new this(config, options);
+	}
+
+	constructor(config, options) {
+		this._atomizer = new Atomizer();
+		this._config = config;
+		this._options = options;
+	}
+
+	generate(str) {
+		const classes = this._atomizer.findClassNames(str);
+		const config = this._atomizer.getConfig(classes, this._config);
+		const css = this._atomizer.getCss(config, this._options);
+
+		return css;
+	}
+}
+
+module.exports = Style;

--- a/style.test.js
+++ b/style.test.js
@@ -1,0 +1,38 @@
+const Style = require('./style');
+
+describe('Style', () => {
+	describe('#generate', () => {
+		test('non atomic class', () => {
+			expect(
+				Style.instance({config: {}, options: {}}).generate('not atomic'),
+			).toBe('');
+		});
+
+		test('atomic class', () => {
+			expect(
+				Style.instance({config: {}, options: {}})
+					.generate('Bd(n)')
+					.replace(/[\n\t]+|\s{2,}/g, ''),
+			).toBe(`.Bd\\(n\\) {border: none;}`);
+		});
+
+		test('atomizer options', () => {
+			expect(
+				Style.instance({config: {}, options: {namespace: '.atomic'}})
+					.generate('Bd(n)')
+					.replace(/[\n\t]+|\s{2,}/g, ''),
+			).toBe('.atomic .Bd\\(n\\), .Bd\\(n\\) {border: none;}');
+		});
+
+		test('atomizer configuration', () => {
+			expect(
+				Style.instance({
+					config: {custom: {'1': '1px solid #000'}},
+					options: {},
+				})
+					.generate('Bd(1)')
+					.replace(/[\n\t]+|\s{2,}/g, ''),
+			).toBe('.Bd\\(1\\) {border: 1px solid #000;}');
+		});
+	});
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -428,6 +428,16 @@ atob@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.0.3.tgz#19c7a760473774468f20b2d2d03372ad7d4cbf5d"
 
+atomizer@^3.4.7:
+  version "3.4.7"
+  resolved "https://registry.yarnpkg.com/atomizer/-/atomizer-3.4.7.tgz#5b30661c74986ecb8edd0dae47bc64556ccc4378"
+  dependencies:
+    chalk "^1.0.0"
+    commander "^2.8.0"
+    lodash "^4.0.0"
+    object-assign "^4.0.0"
+    xregexp "^3.0.0"
+
 author-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/author-regex/-/author-regex-1.0.0.tgz#d08885be6b9bbf9439fe087c76287245f0a81450"
@@ -1008,7 +1018,7 @@ combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.9.0:
+commander@^2.8.0, commander@^2.9.0:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
 
@@ -1330,7 +1340,7 @@ debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debuglog@^1.0.1:
+debuglog@*, debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
 
@@ -1470,11 +1480,39 @@ doctrine@^2.1.0:
   dependencies:
     esutils "^2.0.2"
 
+dom-serializer@0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
+  dependencies:
+    domelementtype "~1.1.1"
+    entities "~1.1.1"
+
+domelementtype@1, domelementtype@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
+
+domelementtype@~1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
+
 domexception@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
   dependencies:
     webidl-conversions "^4.0.2"
+
+domhandler@^2.3.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.1.tgz#892e47000a99be55bbf3774ffea0561d8879c259"
+  dependencies:
+    domelementtype "1"
+
+domutils@^1.5.1:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
 
 dot-prop@^3.0.0:
   version "3.0.0"
@@ -1543,6 +1581,10 @@ enhance-visitors@^1.0.0:
   resolved "https://registry.yarnpkg.com/enhance-visitors/-/enhance-visitors-1.0.0.tgz#aa945d05da465672a1ebd38fee2ed3da8518e95a"
   dependencies:
     lodash "^4.13.1"
+
+entities@^1.1.1, entities@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
 env-editor@^0.3.1:
   version "0.3.1"
@@ -2489,6 +2531,10 @@ hoek@4.x.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
 
+hoek@5.x.x:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/hoek/-/hoek-5.0.3.tgz#b71d40d943d0a95da01956b547f83c4a5b4a34ac"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -2509,6 +2555,17 @@ html-encoding-sniffer@^1.0.2:
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
   dependencies:
     whatwg-encoding "^1.0.1"
+
+htmlparser2@^3.9.2:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
+  dependencies:
+    domelementtype "^1.3.0"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^2.0.2"
 
 http-cache-semantics@^3.8.0:
   version "3.8.1"
@@ -2577,7 +2634,7 @@ import-modules@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/import-modules/-/import-modules-1.1.0.tgz#748db79c5cc42bb9701efab424f894e72600e9dc"
 
-imurmurhash@^0.1.4:
+imurmurhash@*, imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
@@ -2960,11 +3017,17 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
+isemail@3.x.x:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/isemail/-/isemail-3.1.1.tgz#e8450fe78ff1b48347db599122adcd0668bd92b5"
+  dependencies:
+    punycode "2.x.x"
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
-isobject@^2.0.0:
+isobject@^2.0.0, isobject@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
   dependencies:
@@ -3315,6 +3378,14 @@ jest@^22.4.2:
     import-local "^1.0.0"
     jest-cli "^22.4.2"
 
+joi@^13.1.2:
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-13.1.2.tgz#b2db260323cc7f919fafa51e09e2275bd089a97e"
+  dependencies:
+    hoek "5.x.x"
+    isemail "3.x.x"
+    topo "3.x.x"
+
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
@@ -3533,6 +3604,10 @@ lockfile@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/lockfile/-/lockfile-1.0.3.tgz#2638fc39a0331e9cac1a04b71799931c9c50df79"
 
+lodash._baseindexof@*:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
+
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -3540,9 +3615,27 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
+lodash._bindcallback@*:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
+
+lodash._cacheindexof@*:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
+
+lodash._createcache@*:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
+  dependencies:
+    lodash._getnative "^3.0.0"
+
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
+
+lodash._getnative@*, lodash._getnative@^3.0.0:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
 
 lodash._reinterpolate@~3.0.0:
   version "3.0.0"
@@ -3572,7 +3665,7 @@ lodash.kebabcase@4.1.1, lodash.kebabcase@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
 
-lodash.merge@4.6.1:
+lodash.merge@4.6.1, lodash.merge@^4.6.1:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
 
@@ -3587,6 +3680,10 @@ lodash.omit@4.5.0:
 lodash.pick@4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+
+lodash.restparam@*:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
 lodash.snakecase@4.1.1, lodash.snakecase@^4.0.1:
   version "4.1.1"
@@ -3637,7 +3734,7 @@ lodash.zip@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
 
-lodash@^4.12.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.12.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
@@ -4253,7 +4350,7 @@ obj-props@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/obj-props/-/obj-props-1.1.0.tgz#626313faa442befd4a44e9a02c3cb6bde937b511"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.0, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -4594,6 +4691,26 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
 
+posthtml-parser@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/posthtml-parser/-/posthtml-parser-0.3.3.tgz#3fe986fca9f00c0f109d731ba590b192f26e776d"
+  dependencies:
+    htmlparser2 "^3.9.2"
+    isobject "^2.1.0"
+    object-assign "^4.1.1"
+
+posthtml-render@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/posthtml-render/-/posthtml-render-1.1.2.tgz#1755717c3ad12f4e6d8846767fa2f0bafdd7f33f"
+
+posthtml@^0.11.3:
+  version "0.11.3"
+  resolved "https://registry.yarnpkg.com/posthtml/-/posthtml-0.11.3.tgz#17ea2921b0555b7455f33c977bd16d8b8cb74f27"
+  dependencies:
+    object-assign "^4.1.1"
+    posthtml-parser "^0.3.3"
+    posthtml-render "^1.1.0"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -4712,13 +4829,13 @@ pumpify@^1.3.3:
     inherits "^2.0.3"
     pump "^2.0.0"
 
+punycode@2.x.x, punycode@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
-
-punycode@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
 
 q@^1.4.1, q@^1.5.1:
   version "1.5.1"
@@ -4864,7 +4981,7 @@ readable-stream@~1.1.10:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   dependencies:
@@ -5069,8 +5186,8 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
 resolve@^1.3.3, resolve@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.6.0.tgz#0fbd21278b27b4004481c395349e7aba60a9ff5c"
   dependencies:
     path-parse "^1.0.5"
 
@@ -5639,6 +5756,17 @@ tar@^2.0.0, tar@^2.2.1, tar@~2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
+temp-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
+
+tempy@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tempy/-/tempy-0.2.1.tgz#9038e4dbd1c201b74472214179bc2c6f7776e54c"
+  dependencies:
+    temp-dir "^1.0.0"
+    unique-string "^1.0.0"
+
 term-size@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
@@ -5721,6 +5849,12 @@ to-regex@^3.0.1:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+topo@3.x.x:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/topo/-/topo-3.0.0.tgz#37e48c330efeac784538e0acd3e62ca5e231fe7a"
+  dependencies:
+    hoek "5.x.x"
 
 tough-cookie@>=2.3.3, tough-cookie@^2.3.3, tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   version "2.3.4"
@@ -5907,7 +6041,7 @@ uuid@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 
-validate-npm-package-license@^3.0.1:
+validate-npm-package-license@*, validate-npm-package-license@^3.0.1:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz#81643bcbef1bdfecd4623793dc4648948ba98338"
   dependencies:
@@ -6135,6 +6269,10 @@ xo@^0.20.3:
     slash "^1.0.0"
     update-notifier "^2.3.0"
     xo-init "^0.7.0"
+
+xregexp@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-3.2.0.tgz#cb3601987bfe2695b584000c18f1c4a8c322878e"
 
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.1"


### PR DESCRIPTION
# What

Implements the posthtml plugin:

- [x] validate and default options (throw if invalid)
- [x] extract class strings from every html tag
- [x] generate css from the class strings
- [x] emit the css as a file

# Why

So that posthtml (and whatever else uses posthtml) can generate atomic css by way of atomizer.